### PR TITLE
visual_studio_multi_toolset removed, made default

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -13,7 +13,6 @@ from .qbs import QbsGenerator
 from .scons import SConsGenerator
 from .visualstudio import VisualStudioGenerator
 from .visualstudio_multi import VisualStudioMultiGenerator
-from .visualstudio_multi import VisualStudioMultiToolsetGenerator
 from .visualstudiolegacy import VisualStudioLegacyGenerator
 from .xcode import XCodeGenerator
 from .ycm import YouCompleteMeGenerator
@@ -53,7 +52,6 @@ registered_generators.add("qbs", QbsGenerator)
 registered_generators.add("scons", SConsGenerator)
 registered_generators.add("visual_studio", VisualStudioGenerator)
 registered_generators.add("visual_studio_multi", VisualStudioMultiGenerator)
-registered_generators.add("visual_studio_toolset_multi", VisualStudioMultiToolsetGenerator)
 registered_generators.add("visual_studio_legacy", VisualStudioLegacyGenerator)
 registered_generators.add("xcode", XCodeGenerator)
 registered_generators.add("ycm", YouCompleteMeGenerator)

--- a/conans/test/generators/visual_studio_multi_test.py
+++ b/conans/test/generators/visual_studio_multi_test.py
@@ -1,101 +1,33 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import unittest
 import os
+
 from nose.plugins.attrib import attr
+from nose_parameterized import parameterized
+
 from conans.model.settings import Settings
 from conans.model.conan_file import ConanFile
 from conans.model.build_info import CppInfo
 from conans.model.ref import ConanFileReference
 from conans.client.conf import default_settings_yml
-
 from conans.client.generators import VisualStudioMultiGenerator
 from conans.tools import chdir
 from conans.test.utils.test_files import temp_folder
-from conans.client.generators.visualstudio_multi import VisualStudioMultiToolsetGenerator
 
 
 @attr('visual_studio')
 class VisualStudioMultiGeneratorTest(unittest.TestCase):
-    def valid_xml_test(self):
 
+    @parameterized.expand([(False, ), (True, )])
+    def valid_xml_test(self, use_toolset):
         tempdir = temp_folder()
         with chdir(tempdir):
             settings = Settings.loads(default_settings_yml)
             settings.os = "Windows"
             settings.compiler = "Visual Studio"
-            settings.compiler.version = "12"
+            settings.compiler.version = "11"
             settings.compiler.runtime = "MD"
-            conanfile = ConanFile(None, None, Settings({}), None)
-
-            ref = ConanFileReference.loads("MyPkg/0.1@user/testing")
-            cpp_info = CppInfo("dummy_root_folder1")
-            conanfile.deps_cpp_info.update(cpp_info, ref.name)
-            ref = ConanFileReference.loads("My.Fancy-Pkg_2/0.1@user/testing")
-            cpp_info = CppInfo("dummy_root_folder2")
-            conanfile.deps_cpp_info.update(cpp_info, ref.name)
-
-            settings.arch = "x86"
-            settings.build_type = "Debug"
-            settings.compiler.version = "12"
-            conanfile.settings = settings
-
-            generator = VisualStudioMultiGenerator(conanfile)
-            generator.output_path = ""
-            content = generator.content
-
-            self.assertEqual(2, len(content))
-            self.assertIn('conanbuildinfo_multi.props', content.keys())
-            self.assertIn('conanbuildinfo_debug_win32_12.props', content.keys())
-
-            content_multi = content['conanbuildinfo_multi.props']
-            self.assertIn("<Import Condition=\"'$(Configuration)' == 'Debug' "
-                          "And '$(Platform)' == 'Win32' "
-                          "And '$(VisualStudioVersion)' == '12.0'\" "
-                          "Project=\"conanbuildinfo_debug_win32_12.props\"/>", content_multi)
-
-            with open('conanbuildinfo_multi.props', 'w') as f:
-                f.write(content_multi)
-
-            settings.arch = "x86_64"
-            settings.build_type = "Release"
-            settings.compiler.version = "14"
-            conanfile.settings = settings
-
-            generator = VisualStudioMultiGenerator(conanfile)
-            generator.output_path = ""
-            content = generator.content
-
-            self.assertEqual(2, len(content))
-            self.assertIn('conanbuildinfo_multi.props', content.keys())
-            self.assertIn('conanbuildinfo_release_x64_14.props', content.keys())
-
-            content_multi = content['conanbuildinfo_multi.props']
-            self.assertIn("<Import Condition=\"'$(Configuration)' == 'Debug' "
-                          "And '$(Platform)' == 'Win32' "
-                          "And '$(VisualStudioVersion)' == '12.0'\" "
-                          "Project=\"conanbuildinfo_debug_win32_12.props\"/>", content_multi)
-            self.assertIn("<Import Condition=\"'$(Configuration)' == 'Release' "
-                          "And '$(Platform)' == 'x64' "
-                          "And '$(VisualStudioVersion)' == '14.0'\" "
-                          "Project=\"conanbuildinfo_release_x64_14.props\"/>", content_multi)
-
-            os.unlink('conanbuildinfo_multi.props')
-
-
-@attr('visual_studio')
-class VisualStudioMultiToolsetGeneratorTest(unittest.TestCase):
-    def valid_xml_test(self):
-
-        tempdir = temp_folder()
-        with chdir(tempdir):
-            settings = Settings.loads(default_settings_yml)
-            settings.os = "Windows"
-            settings.compiler = "Visual Studio"
-            settings.compiler.version = "12"
-            settings.compiler.runtime = "MD"
-            settings.compiler.toolset = "v110"
+            if use_toolset:
+                settings.compiler.toolset = "v110"
             conanfile = ConanFile(None, None, Settings({}), None)
 
             ref = ConanFileReference.loads("MyPkg/0.1@user/testing")
@@ -109,7 +41,7 @@ class VisualStudioMultiToolsetGeneratorTest(unittest.TestCase):
             settings.build_type = "Debug"
             conanfile.settings = settings
 
-            generator = VisualStudioMultiToolsetGenerator(conanfile)
+            generator = VisualStudioMultiGenerator(conanfile)
             generator.output_path = ""
             content = generator.content
 
@@ -128,11 +60,11 @@ class VisualStudioMultiToolsetGeneratorTest(unittest.TestCase):
 
             settings.arch = "x86_64"
             settings.build_type = "Release"
-            settings.compiler.version = "14"
+            settings.compiler.version = "15"
             settings.compiler.toolset = "v141"
             conanfile.settings = settings
 
-            generator = VisualStudioMultiToolsetGenerator(conanfile)
+            generator = VisualStudioMultiGenerator(conanfile)
             generator.output_path = ""
             content = generator.content
 


### PR DESCRIPTION
This PR removes the ``visual_studio_multi_toolset`` generator and makes it the default ``visual_studio_multi`` one, which is valid for all use cases with the default conversion from version => toolset, and doesn't use versions anymore.

Feedback very welcome :)
cc / @SSE4